### PR TITLE
Add mod support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ RCONPORT=21114
 FIXEDMAXPLAYERS=80
 FIXEDMAXTICKRATE=50
 RANDOM=NONE
+MODS="()"
 ```
 
 ## Config
@@ -72,6 +73,14 @@ $ docker exec -it squad-dedicated nano /home/steam/squad-dedicated/SquadGame/Ser
 ```
 
 If you want to learn more about configuring a Squad server check this [documentation](https://squad.gamepedia.com/Server_Configuration).
+
+## Mods
+
+Add each id to the MODS environment variable, for example `MODS="(13371337 12341234 1111111)"`
+
+> MODS must be a bash array `(mod1id mod2id mod3id)` where each mod id is separated by a space and inclosed in brackets
+
+You can get the mod id from the workshop url or by installing it locally and lookup the numeric folder name at `<root_steam_folder>/steamapps/workshop/content/393380`.
 
 # Contributors
 [![Contributors Display](https://badges.pufler.dev/contributors/CM2Walki/Squad?size=50&padding=5&bots=false)](https://github.com/CM2Walki/Squad/graphs/contributors)

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -17,7 +17,7 @@ ENV WORKSHOPID 393380
 ENV MODPATH "${STEAMAPPDIR}/SquadGame/Plugins/Mods"
 ENV MODS "()"
 
-ADD etc/entry.sh ${HOMEDIR}
+COPY etc/entry.sh ${HOMEDIR}
 
 RUN set -x \
 	&& mkdir -p "${STEAMAPPDIR}" \

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -8,24 +8,21 @@ LABEL maintainer="walentinlamonos@gmail.com"
 ENV STEAMAPPID 403240
 ENV STEAMAPP squad
 ENV STEAMAPPDIR "${HOMEDIR}/${STEAMAPP}-dedicated"
-ENV DLURL https://raw.githubusercontent.com/CM2Walki/Squad
 
 ENV STEAM_BETA_APP 774961
 ENV STEAM_BETA_PASSWORD ""
 ENV STEAM_BETA_BRANCH ""
 
+ENV WORKSHOPID 393380
+ENV MODPATH "${STEAMAPPDIR}/SquadGame/Plugins/Mods"
+ENV MODS "()"
+
+ADD etc/entry.sh ${HOMEDIR}
+
 RUN set -x \
-	# Install, update & upgrade packages
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends --no-install-suggests \
-		wget=1.21-1+deb11u1 \
-	# Add entry script
-	&& wget "${DLURL}/master/etc/entry.sh" -O "${HOMEDIR}/entry.sh" \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	&& chmod 755 "${HOMEDIR}/entry.sh" "${STEAMAPPDIR}" \
-	&& chown "${USER}:${USER}" "${HOMEDIR}/entry.sh" "${STEAMAPPDIR}" \
-	# Clean up
-	&& rm -rf /var/lib/apt/lists/*
+	&& chown "${USER}:${USER}" "${HOMEDIR}/entry.sh" "${STEAMAPPDIR}"
 
 ENV PORT=7787 \
 	QUERYPORT=27165 \

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -19,6 +19,27 @@ fi
 # Change rcon port on first launch, because the default config overwrites the commandline parameter (you can comment this out if it has done it's purpose)
 sed -i -e 's/Port=21114/'"Port=${RCONPORT}"'/g' "${STEAMAPPDIR}/SquadGame/ServerConfig/Rcon.cfg"
 
+echo "Clearing Mods..."
+# Clear all workshop mods:
+# find all folders / files in mods folder which are numeric only;
+# remove the workshop mods
+find $MODPATH/* -maxdepth 0 -regextype posix-egrep -regex ".*/[[:digit:]]+" | xargs -d"\n" rm -R 2>/dev/null
+
+# Install mods (if defined)
+declare -a MODS="$MODS"
+if (( ${#MODS[@]} ))
+then
+	echo "Installing Mods..."
+	for MODID in ${MODS[@]}; do
+		echo "> Install mod '${MODID}'"
+		"${STEAMCMDDIR}/steamcmd.sh" +force_install_dir $STEAMAPPDIR +login anonymous +workshop_download_item $WORKSHOPID $MODID +quit
+
+		echo -e "\n> Link mod content '${MODID}'"
+		# cp -R "${STEAMAPPDIR}/steamapps/workshop/content/${WORKSHOPID}/${MODID}" "${MODPATH}/${MODID}" 2>/dev/null
+		ln -s "${STEAMAPPDIR}/steamapps/workshop/content/${WORKSHOPID}/${MODID}" "${MODPATH}/${MODID}"
+	done
+fi
+
 bash "${STEAMAPPDIR}/SquadGameServer.sh" \
 			Port="${PORT}" \
 			QueryPort="${QUERYPORT}" \

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -35,7 +35,6 @@ then
 		"${STEAMCMDDIR}/steamcmd.sh" +force_install_dir $STEAMAPPDIR +login anonymous +workshop_download_item $WORKSHOPID $MODID +quit
 
 		echo -e "\n> Link mod content '${MODID}'"
-		# cp -R "${STEAMAPPDIR}/steamapps/workshop/content/${WORKSHOPID}/${MODID}" "${MODPATH}/${MODID}" 2>/dev/null
 		ln -s "${STEAMAPPDIR}/steamapps/workshop/content/${WORKSHOPID}/${MODID}" "${MODPATH}/${MODID}"
 	done
 fi

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -z "$STEAM_BETA_BRANCH" ]
+if [ -n "${STEAM_BETA_BRANCH}" ]
 then
 	echo "Loading Steam Beta Branch"
 	bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
@@ -23,16 +23,16 @@ echo "Clearing Mods..."
 # Clear all workshop mods:
 # find all folders / files in mods folder which are numeric only;
 # remove the workshop mods
-find $MODPATH/* -maxdepth 0 -regextype posix-egrep -regex ".*/[[:digit:]]+" | xargs -d"\n" rm -R 2>/dev/null
+find "${MODPATH}"/* -maxdepth 0 -regextype posix-egrep -regex ".*/[[:digit:]]+" | xargs -0 -d"\n" rm -R 2>/dev/null
 
 # Install mods (if defined)
-declare -a MODS="$MODS"
+declare -a MODS="${MODS}"
 if (( ${#MODS[@]} ))
 then
 	echo "Installing Mods..."
-	for MODID in ${MODS[@]}; do
+	for MODID in "${MODS[@]}"; do
 		echo "> Install mod '${MODID}'"
-		"${STEAMCMDDIR}/steamcmd.sh" +force_install_dir $STEAMAPPDIR +login anonymous +workshop_download_item $WORKSHOPID $MODID +quit
+		"${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" +login anonymous +workshop_download_item "${WORKSHOPID}" "${MODID}" +quit
 
 		echo -e "\n> Link mod content '${MODID}'"
 		ln -s "${STEAMAPPDIR}/steamapps/workshop/content/${WORKSHOPID}/${MODID}" "${MODPATH}/${MODID}"


### PR DESCRIPTION
Fixes https://github.com/CM2Walki/Squad/issues/22

`entry.sh` will download / update mods each start and link them to the game server mods folder.
I tested link and it worked.
The wiki uses copy command but that's for windows and linking instead of copy does save storage and it's faster as well.

I also removed the wget `entry.sh` for my fork, because it wouldn't be possible of course.
Is there a reason to do this actually?
To me this is unnecessary and would just allow to exploit later the image in case someone gets access to this repo.

I also removed installing wget and such (not needed anymore and the root image does it already)

Of course only the mod feature can be easily merged in ;)

Feedback is welcome.
My image for testing was also pushed here: `https://hub.docker.com/repository/docker/thedelta/squad`